### PR TITLE
Use unpacked_dir option in BinDeps

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -9,8 +9,8 @@ provides(Sources,
          libgumbo,
          unpacked_dir="gumbo-1.0")
 
-provides(Binaries, URI("http://sourceforge.net/projects/juliadeps-win/files/gumbo-$(Sys.MACHINE).7z"),
-         libgumbo, os = :Windows)
+provides(Binaries, URI("http://sourceforge.net/projects/juliadeps-win/files/gumbo.7z"),
+         libgumbo, unpacked_dir="usr$WORD_SIZE/bin", os = :Windows)
 
 provides(BuildProcess,
          Autotools(libtarget="libgumbo.la"),


### PR DESCRIPTION
This allows 32 and 64 bit installations to coexist on the same machine, like Jameson said (sorry for hijacking your mailing list thread with BinDeps stuff, this is a really useful library to have wrapped)

Windows build is green: https://ci.appveyor.com/project/tkelman/gumbo-jl/build/1.0.3
