### PR TITLE
Modernize to Julia 0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,16 @@
-language: cpp
-compiler:
-  - clang
+language: julia
+os:
+    - linux
+    - osx
+julia:
+    - 0.4
+    - nightly
 notifications:
-  email: false
-env:
-  matrix:
-   - JULIAVERSION="juliareleases"
-   - JULIAVERSION="julianightlies"
-before_install:
-  - sudo add-apt-repository ppa:staticfloat/julia-deps -y
-  - sudo add-apt-repository ppa:staticfloat/${JULIAVERSION} -y
-  - sudo apt-get update -qq -y
-  - sudo apt-get install libpcre3-dev julia -y
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+    email: false
+sudo: false
 script:
-  - julia -e 'Pkg.init(); Pkg.clone(pwd()); Pkg.build("Gumbo"); Pkg.test("Gumbo")'
+    - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+    - julia -e 'Pkg.clone(pwd()); Pkg.build("Gumbo"); Pkg.test("Gumbo"; coverage=true)';
+after_success:
+    - julia -e 'cd(Pkg.dir("Gumbo")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())';
+

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.3
+julia 0.4
 BinDeps
 Compat
 

--- a/src/CGumbo.jl
+++ b/src/CGumbo.jl
@@ -12,7 +12,7 @@ immutable Vector  # Gumbo vector
 end
 
 immutable StringPiece
-    data::Ptr{Uint8}
+    data::Ptr{UInt8}
     length::Csize_t
 end
 
@@ -23,7 +23,7 @@ immutable SourcePosition
 end
 
 immutable Text
-    text::Ptr{Uint8}
+    text::Ptr{UInt8}
     original_text::StringPiece
     start_pos::SourcePosition
 end
@@ -39,17 +39,17 @@ const WHITESPACE = @compat Int32(4)
 immutable Document
     children::Vector
     has_doctype::Bool
-    name::Ptr{Uint8}
-    public_identifier::Ptr{Uint8}
-    system_identifier::Ptr{Uint8}
+    name::Ptr{UInt8}
+    public_identifier::Ptr{UInt8}
+    system_identifier::Ptr{UInt8}
     doc_type_quirks_mode::Int32  # enum
 end
 
 immutable Attribute
     attr_namespace::Int32  # enum
-    name::Ptr{Uint8}
+    name::Ptr{UInt8}
     original_name::StringPiece
-    value::Ptr{Uint8}
+    value::Ptr{UInt8}
     original_value::StringPiece
     name_start::SourcePosition
     name_end::SourcePosition

--- a/src/comparison.jl
+++ b/src/comparison.jl
@@ -9,12 +9,14 @@
 
 # equality
 
-Base.isequal(x::HTMLDocument, y::HTMLDocument) =
+import Base: ==, isequal, hash
+
+isequal(x::HTMLDocument, y::HTMLDocument) =
     isequal(x.doctype,y.doctype) && isequal(x.root,y.root)
 
-Base.isequal(x::HTMLText,y::HTMLText) = isequal(x.text, y.text)
+isequal(x::HTMLText,y::HTMLText) = isequal(x.text, y.text)
 
-Base.isequal(x::HTMLElement, y::HTMLElement) =
+isequal(x::HTMLElement, y::HTMLElement) =
     isequal(x.attributes,y.attributes) && isequal(x.children,y.children)
 
 ==(x::HTMLDocument, y::HTMLDocument) =
@@ -28,11 +30,11 @@ Base.isequal(x::HTMLElement, y::HTMLElement) =
 
 # hashing
 
-function Base.hash(doc::HTMLDocument)
+function hash(doc::HTMLDocument)
     hash(hash(HTMLDocument),hash(hash(doc.doctype), hash(doc.root)))
 end
 
-function Base.hash{T}(elem::HTMLElement{T})
+function hash{T}(elem::HTMLElement{T})
     h = hash(HTMLElement)
     h = hash(h,hash(T))
     h = hash(h,hash(attrs(elem)))
@@ -42,5 +44,4 @@ function Base.hash{T}(elem::HTMLElement{T})
     return h
 end
 
-
-Base.hash(t::HTMLText) = hash(hash(HTMLText),hash(t.text))
+hash(t::HTMLText) = hash(hash(HTMLText),hash(t.text))

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -1,7 +1,7 @@
-function parsehtml(input::String; strict=false)
+function parsehtml(input::AbstractString; strict=false)
     result_ptr = ccall((:gumbo_parse,libgumbo),
                        Ptr{CGumbo.Output},
-                       (Ptr{Uint8},),
+                       (Cstring,),
                        input)
     goutput::CGumbo.Output = unsafe_load(result_ptr)
 
@@ -27,9 +27,9 @@ gvector_to_jl(T,gv::CGumbo.Vector) = pointer_to_array(convert(Ptr{Ptr{T}},gv.dat
 
 
 # convert a vector of pointers to GumboAttributes to
-# a Dict String => String
+# a Dict AbstractString => AbstractString
 function attributes(av::Vector{Ptr{CGumbo.Attribute}})
-    result = Dict{String,String}()
+    result = Dict{AbstractString,AbstractString}()
     for ptr in av
         ga::CGumbo.Attribute = unsafe_load(ptr)
         result[bytestring(ga.name)] = bytestring(ga.value)

--- a/src/htmltypes.jl
+++ b/src/htmltypes.jl
@@ -3,28 +3,28 @@ abstract HTMLNode
 # TODO immutable?
 type HTMLText <: HTMLNode
     parent::HTMLNode
-    text::String
+    text::AbstractString
 end
 
 # convenience method for defining without parent
-HTMLText(text::String) = HTMLText(NullNode(), text)
+HTMLText(text::AbstractString) = HTMLText(NullNode(), text)
 
 type NullNode <: HTMLNode end
 
 type HTMLElement{T} <: HTMLNode
     children::Vector{HTMLNode}
     parent::HTMLNode
-    attributes::Dict{String, String}
+    attributes::Dict{AbstractString,AbstractString}
 end
 
 # convenience method for defining an empty element
-HTMLElement(T::Symbol) = HTMLElement{T}(HTMLNode[],NullNode(),Dict{String,String}())
+HTMLElement(T::Symbol) = HTMLElement{T}(HTMLNode[],NullNode(),Dict{AbstractString,AbstractString}())
 
 type HTMLDocument
-    doctype::String
+    doctype::AbstractString
     root::HTMLElement
 end
 
 type InvalidHTMLException <: Exception
-    msg::String
+    msg::AbstractString
 end

--- a/src/manipulation.jl
+++ b/src/manipulation.jl
@@ -5,7 +5,7 @@
 tag{T}(elem::HTMLElement{T}) = T
 
 attrs(elem::HTMLElement) = elem.attributes
-function setattr!(elem::HTMLElement, name::String, value::String)
+function setattr!(elem::HTMLElement, name::AbstractString, value::AbstractString)
     elem.attributes[name] = value
 end
 getattr(elem::HTMLElement, name) = elem.attributes[name]
@@ -16,7 +16,7 @@ children(elem::HTMLElement) = elem.children
 # breadthfirst traversal will have to be updated
 children(elem::HTMLNode) = HTMLNode[]
 
-# indexing into an element indexes into it's children
+# indexing into an element indexes into its children
 Base.getindex(elem::HTMLElement,i) = getindex(elem.children,i)
 Base.setindex!(elem::HTMLElement,i,val) = setindex!(elem.children,i,val)
 

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -5,7 +5,7 @@ import Gumbo: HTMLNode, NullNode
 # convenience constructor works
 @test HTMLElement(:body) == HTMLElement{:body}(HTMLNode[],
                                                NullNode(),
-                                               Dict{String,String}())
+                                               Dict{AbstractString,AbstractString}())
 
 # accessing tags works
 @test HTMLElement(:body) |> tag == :body


### PR DESCRIPTION
This PR removes deprecation warnings in 0.4 and also updates the Travis configuration.

Would appreciate a new `:minor` version tag after merging this :)