### PR TITLE
On branch DeprSource

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -9,11 +9,11 @@ provides(Sources,
          libgumbo,
          unpacked_dir="gumbo-1.0")
 
-provides(Binaries, URI("https://cache.e.ip.saba.us/https://bintray.com/artifact/download/tkelman/generic/gumbo.7z"),
+provides(Binaries, URI("https://cache.julialang.org/https://bintray.com/artifact/download/tkelman/generic/gumbo.7z"),
          libgumbo, unpacked_dir="usr$WORD_SIZE/bin", os = :Windows)
 
 provides(BuildProcess,
          Autotools(libtarget="libgumbo.la"),
          libgumbo, os = :Unix)
 
-@BinDeps.install [:libgumbo => :libgumbo]
+@BinDeps.install Dict(:libgumbo => :libgumbo)


### PR DESCRIPTION
Looking forward to using this package! But it did not build on windows. Ref. issue https://github.com/porterjamesj/Gumbo.jl/issues/17

I changed the source for windows binaries to cache.julialang.org due to outdated https certificate in previous source. Based on. https://github.com/JuliaLang/WinRPM.jl/issues/68

Also fixed deprecation warning.