### PR TITLE
Fix for incorrect parsing of custom html elements

### DIFF
--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -41,7 +41,7 @@ function elem_tag(ge::CGumbo.Element)
     tag = CGumbo.TAGS[ge.tag+1]  # +1 is for 1-based julia indexing
     if tag == :unknown
         ot = ge.original_tag
-        tag = unsafe_string(ot.data, ot.length)[2:end-1] |> Symbol
+        tag = split(unsafe_string(ot.data, ot.length)[2:end-1])[1] |> Symbol
     end
     tag
 end

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -22,3 +22,12 @@ let
     page = parsehtml("<weird></weird")
     @test tag(page.root[2][1]) == :weird
 end
+
+
+# test that non-standard tags, with attributes, are parsed correctly
+
+let
+    page = Gumbo.parsehtml("<my-element cool></my-element>")
+    @test tag(page.root[2][1]) == Symbol("my-element")
+    @test Gumbo.attrs(page.root[2][1]) == Dict("cool" => "")
+end


### PR DESCRIPTION
Without the fix, `<my-element cool></my-element>` would be parsed as `<my-element cool cool=""></my-element cool>`. With the fix, it is correctly parsed as `<my-element cool=""></my-element>`