### PR TITLE
Reference new gumbo-parser upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,8 @@
 [![version](https://juliahub.com/docs/Gumbo/version.svg)](https://juliahub.com/ui/Packages/Gumbo/mllB2) [![Build Status](https://travis-ci.org/JuliaWeb/Gumbo.jl.svg?branch=master)](https://travis-ci.org/JuliaWeb/Gumbo.jl) [![codecov.io](http://codecov.io/github/JuliaWeb/Gumbo.jl/coverage.svg?branch=master)](http://codecov.io/github/JuliaWeb/Gumbo.jl?branch=master) [![pkgeval](https://juliahub.com/docs/Gumbo/pkgeval.svg)](https://juliahub.com/ui/Packages/Gumbo/mllB2) [![deps](https://juliahub.com/docs/Gumbo/deps.svg)](https://juliahub.com/ui/Packages/Gumbo/mllB2?t=2)
 
 Gumbo.jl is a Julia wrapper around
-[the gumbo library](https://github.com/google/gumbo-parser) for
+[the gumbo library](https://codeberg.org/gumbo-parser/gumbo-parser) for
 parsing HTML.
-
-> [!WARNING]  
-> The underlying C library is currently unmaintained. Use at your own risk.
 
 Getting started is very easy:
 


### PR DESCRIPTION
Hello, Gumbo.jl developers. Thank you for maintaining these nice bindings!

Since the original gumbo-parser repository was archived, significant progress has been made in the new, actively maintained repository. The version from the original repo has fallen far behind in terms of HTML specification compliance and contains several critical bugs.

Over the past year, gumbo-parser has seen substantial improvements. It now passes all html5lib-tests, has better unit tests coverage, uses modern build system and has fuzzy testing facilities. You can find the updated repository here: https://codeberg.org/gumbo-parser/gumbo-parser

Many major distributions have already adopted the updated version, including Alpine, Arch, Debian, Fedora, FreeBSD, Gentoo, Homebrew, NixOS, OpenBSD, Slackware, Ubuntu, and others.

I'm the new maintainer of Gumbo, by the way. My main incentive for taking on this job is the use of Gumbo in my other projects, one public one of which is the [Newsraft](https://codeberg.org/newsraft/newsraft).

So I just would like to try to alleviate your doubts about the reliability of Gumbo as a dependency. I plan to support it for as long as possible with the respect to all the initial ideas laid out by the original author of Gumbo. If you ever encounter any problems with the library, feel free to reach out at https://codeberg.org/gumbo-parser/gumbo-parser/issues

Best regards, Grigory